### PR TITLE
remove scc_id from product names

### DIFF
--- a/app/models/scc_product.rb
+++ b/app/models/scc_product.rb
@@ -20,7 +20,7 @@ class SccProduct < ActiveRecord::Base
   scoped_search on: :name, complete_value: true
 
   def uniq_name
-    return "#{scc_id} " + friendly_name;
+    return friendly_name
   end
 
   def subscribe


### PR DESCRIPTION
I don't see a need to have the scc id in the names of the products created in katello. This is just a cosmetical change, maybe you can make an option of it if you really want the scc id inside product names
