### PR TITLE
Force katello to load before scc_manager

### DIFF
--- a/lib/foreman_scc_manager/engine.rb
+++ b/lib/foreman_scc_manager/engine.rb
@@ -1,3 +1,5 @@
+require 'katello'
+
 module ForemanSccManager
   class Engine < ::Rails::Engine
     engine_name 'foreman_scc_manager'
@@ -17,6 +19,7 @@ module ForemanSccManager
     initializer 'foreman_scc_manager.register_plugin', :before => :finisher_hook do |_app|
       Foreman::Plugin.register :foreman_scc_manager do
         requires_foreman '>= 1.13'
+        requires_foreman_plugin 'katello', '>= 3.2.0'
 
         # Add permissions
         security_block :foreman_scc_manager do


### PR DESCRIPTION
otherwise it could sometimes happen that katello is loaded after scc manager - then the menu doesn't work