### PR TITLE
resync repository token regularly

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  TargetRubyVersion: 2.3
   Exclude:
     - '*.spec'
     - 'doc/plugins/**'
@@ -71,6 +72,13 @@ Style/FormatString:
   Enabled: false
 
 Style/FormatStringToken:
+  Enabled: false
+
+# Don't enforce frozen string literals
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/NumericPredicate:
   Enabled: false
 
 Style/RegexpLiteral:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,8 +90,14 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Enabled: false
 
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
 Metrics/PerceivedComplexity:
   Enabled: false
 
 Style/CaseEquality:
+  Enabled: false
+
+Style/ConditionalAssignment:
   Enabled: false

--- a/app/controllers/scc_accounts_controller.rb
+++ b/app/controllers/scc_accounts_controller.rb
@@ -18,11 +18,10 @@ class SccAccountsController < ApplicationController
   # POST /scc_accounts
   def create
     @scc_account = SccAccount.new(scc_account_params)
-    if @scc_account.save
-      process_success
-    else
-      process_error
-    end
+    @scc_account.save_with_logic!
+    process_success
+  rescue ActiveRecord::RecordInvalid
+    process_error
   end
 
   # GET /scc_accounts/1/edit
@@ -43,11 +42,10 @@ class SccAccountsController < ApplicationController
 
   # PATCH/PUT /scc_accounts/1
   def update
-    if @scc_account.update(scc_account_params)
-      process_success
-    else
-      process_error
-    end
+    @scc_account.update_attributes_with_logic!(scc_account_params)
+    process_success
+  rescue ActiveRecord::RecordInvalid
+    process_error
   end
 
   # DELETE /scc_accounts/1
@@ -103,7 +101,15 @@ class SccAccountsController < ApplicationController
   # Only allow a trusted parameter "white list" through.
   def scc_account_params
     params[:scc_account].delete(:password) if params[:scc_account][:password].blank?
-    params.require(:scc_account).permit(:name, :login, :password, :base_url, :organization_id)
+    params.require(:scc_account).permit(
+      :name,
+      :login,
+      :password,
+      :base_url,
+      :interval,
+      :sync_date,
+      :organization_id
+    )
   end
 
   def scc_bulk_subscribe_params

--- a/app/lib/actions/scc_manager/sync_plan_account_repositories.rb
+++ b/app/lib/actions/scc_manager/sync_plan_account_repositories.rb
@@ -1,0 +1,38 @@
+module Actions
+  module SccManager
+    class SyncPlanAccountRepositories < Actions::EntryAction
+      include Actions::RecurringAction
+      def plan(scc_account)
+        add_missing_task_group(scc_account)
+        action_subject(scc_account)
+
+        User.as_anonymous_admin do
+          plan_action(::Actions::SccManager::SyncRepositories, scc_account)
+          plan_self(:sync_plan_name => scc_account.name)
+        end
+      end
+
+      def add_missing_task_group(sync_plan)
+        if sync_plan.task_group.nil?
+          sync_plan.task_group = ::SccAccountSyncPlanTaskGroup.create!
+          sync_plan.save!
+        end
+        task.add_missing_task_groups(sync_plan.task_group)
+      end
+
+      def rescue_strategy
+        # Dynflow::Action::Rescue::Skip
+        # REMOVEME
+        Dynflow::Action::Rescue::Fail
+      end
+
+      def humanized_name
+        if input.try(:[], :sync_plan_name)
+          _('Update SUSE repositories %s') % (input[:sync_plan_name] || _('Unknown'))
+        else
+          _('Update SUSE repositories')
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/scc_manager/sync_repositories.rb
+++ b/app/lib/actions/scc_manager/sync_repositories.rb
@@ -9,12 +9,13 @@ module Actions
       end
 
       def run
-        output[:status] = 'SUCCESS'
+        output[:status] = 'IN PROGRESS'
         begin
           output[:data] = ::SccManager.get_scc_data(input[:base_url],
                                                     '/connect/organizations/repositories',
                                                     input[:login],
                                                     input[:password])
+          output[:status] = 'SUCCESS'
         rescue StandardError
           output[:status] = 'FAILURE'
         end
@@ -37,7 +38,7 @@ module Actions
       end
 
       def humanized_output
-        output.dup.update(data: 'Trimmed')
+        output.dup.update(data: "Trimmed (got #{output[:data]&.length} repositories")
       end
     end
   end

--- a/app/models/concerns/recurring_logic_extensions.rb
+++ b/app/models/concerns/recurring_logic_extensions.rb
@@ -1,0 +1,9 @@
+module Concerns
+  module RecurringLogicExtensions
+    extend ActiveSupport::Concern
+
+    included do
+      has_one :scc_account, :inverse_of => :foreman_tasks_recurring_logic, :class_name => 'SccAccount'
+    end
+  end
+end

--- a/app/models/scc_account_sync_plan_task_group.rb
+++ b/app/models/scc_account_sync_plan_task_group.rb
@@ -1,0 +1,7 @@
+class SccAccountSyncPlanTaskGroup < ::ForemanTasks::TaskGroup
+  has_one :scc_account, :foreign_key => :task_group_id, :dependent => :nullify, :inverse_of => :task_group, :class_name => 'SccAccount'
+
+  def resource_name
+    N_('SUSE Subscription')
+  end
+end

--- a/app/views/scc_account_sync_plan_task_groups/_scc_account_sync_plan_task_groups.html.erb
+++ b/app/views/scc_account_sync_plan_task_groups/_scc_account_sync_plan_task_groups.html.erb
@@ -1,0 +1,4 @@
+<%= _("SUSE Subscription: ") %>
+
+<%= link_to(task_groups.first.scc_account.name, "/scc_accounts/#{task_groups.first.scc_account.id}/edit") %>
+

--- a/app/views/scc_accounts/_form.html.erb
+++ b/app/views/scc_accounts/_form.html.erb
@@ -13,6 +13,10 @@
         <%= text_f f, :login, :help_block => _("Use your 'Organization credentials' obtained from the SUSE Customer Center.") %>
         <%= password_f f, :password %>
         <%= text_f f, :base_url, label: _('Base URL') %>
+        <%= selectable_f f, :interval, SccAccount::TYPES, label: _('Interval') %>
+        <%= field f, :sync_date, label: _('Sync Date') do
+          f.datetime_field :sync_date, placeholder: Time.now
+        end %>
         <div class='clearfix'>
           <div class='form-group'>
             <div class='col-md-2'></div>

--- a/db/migrate/20190417202427_add_recurring_sync.foreman_scc_manager.rb
+++ b/db/migrate/20190417202427_add_recurring_sync.foreman_scc_manager.rb
@@ -1,0 +1,26 @@
+class AddRecurringSync < ActiveRecord::Migration[5.2]
+  class FakeSccAccount < ApplicationRecord
+    self.table_name = 'scc_accounts'
+  end
+
+  def up
+    add_column :scc_accounts, :foreman_tasks_recurring_logic_id, :integer
+    add_column :scc_accounts, :interval, :string, default: 'never'
+    add_column :scc_accounts, :sync_date, :datetime
+    add_foreign_key :scc_accounts, :foreman_tasks_recurring_logics, :name => 'scc_accounts_foreman_tasks_recurring_logic_fk', :column => 'foreman_tasks_recurring_logic_id'
+    add_column :scc_accounts, :task_group_id, :integer, index: true
+    add_foreign_key :scc_accounts, :foreman_tasks_task_groups, column: :task_group_id
+    FakeSccAccount.all.each do |scca|
+      scca.task_group_id ||= SccAccountSyncPlanTaskGroup.create!.id
+      scca.save!
+    end
+  end
+
+  def down
+    remove_column :scc_accounts, :foreman_tasks_recurring_logic_id
+    remove_column :scc_accounts, :interval
+    remove_column :scc_accounts, :sync_date
+    remove_column :scc_accounts, :task_group_id
+    ForemanTasks::TaskGroup.where(:type => 'SccAccountSyncPlanTaskGroup').delete_all
+  end
+end

--- a/lib/foreman_scc_manager/engine.rb
+++ b/lib/foreman_scc_manager/engine.rb
@@ -9,6 +9,10 @@ module ForemanSccManager
     config.autoload_paths += Dir["#{config.root}/app/models/concerns"]
     config.autoload_paths += Dir["#{config.root}/app/overrides"]
 
+    config.to_prepare do
+      ForemanTasks::RecurringLogic.send :include, Concerns::RecurringLogicExtensions
+    end
+
     # Add any db migrations
     initializer 'foreman_scc_manager.load_app_instance_data' do |app|
       ForemanSccManager::Engine.paths['db/migrate'].existent.each do |path|

--- a/test/fixtures/models/scc_accounts.yml
+++ b/test/fixtures/models/scc_accounts.yml
@@ -4,6 +4,7 @@ one:
   password: onepass
   base_url: https://scc.example.com
   name: onename
+  interval: never
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
 
 two:
@@ -11,11 +12,13 @@ two:
   password: twopass
   base_url: https://scc.example.com
   name: twoname
+  interval: never
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
 
 account_missing_url:
   login: fakeuser1
   password: fakepass1
   name: fake1
+  interval: never
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
 ...

--- a/test/models/scc_account_test.rb
+++ b/test/models/scc_account_test.rb
@@ -37,6 +37,12 @@ class SccAccountCreateTest < ActiveSupport::TestCase
     end
   end
 
+  test 'create wrong interval-value' do
+    account = scc_accounts(:two)
+    account.interval = 'gazillion'
+    assert_not account.save
+  end
+
   test 'password is saved encrypted when updated' do
     assert SccAccount.encrypts? :password
     @account.expects(:encryption_key).at_least_once.returns('25d224dd383e92a7e0c82b8bf7c985e815f34cf5')


### PR DESCRIPTION
Katello repositories that are created from SCC-products/-repositories get token for authentication at the SCC-server.
These tokens become invalid overtime, which means if the SCC-account is never synced againn manually, the Katello-repositories cannot be synced any more.
This PR adds a recurring logic to the SCC-account class that can be used to regularly re-sync the SCC-repositories (and therefore the authentication-token).

The recurring logic only syncs the scc-repositories and not the scc-products.