### PR TITLE
Fix test-connection on existing account

### DIFF
--- a/app/assets/javascripts/foreman_scc_manager/scc_accounts.js.coffee
+++ b/app/assets/javascripts/foreman_scc_manager/scc_accounts.js.coffee
@@ -26,7 +26,7 @@ $ ->
     $('#connection_test_result')[0].innerHTML = ''
     $('#test_scc_connection_indicator').show()
     $.ajax event.target.parentNode.dataset['url'],
-      type: 'PUT'
+      type: 'POST'
       dataType: 'JSON'
       data: $('form').serialize()
       success: (result) ->

--- a/app/views/scc_accounts/_form.html.erb
+++ b/app/views/scc_accounts/_form.html.erb
@@ -26,7 +26,7 @@
                                    id: 'test_scc_connection_btn',
                                    spinner_id: 'test_scc_connection_indicator',
                                    class: 'btn-default',
-                                   'data-url': test_connection_scc_accounts_path(scc_account_id: @scc_account)) %>
+                                   'data-url': @scc_account.id ? test_connection_scc_account_path : test_connection_scc_accounts_path ) %>
             </div>
             <div class='col-md-2'>
               <span id='connection_test_result'></span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
       get 'auto_complete_search'
     end
     member do
-      put 'test_connection'
+      patch 'test_connection'
       put 'sync'
       put 'bulk_subscribe'
     end


### PR DESCRIPTION
This only works because rails interprets POST on paths for existing accounts as PATCH.
This way we can afford to always do a POST in `scc_accounts.js.coffee`.

I still have to check, whether we have a problem with test-connection in HTTP-Proxy environments.