### PR TITLE
Allow foreman-tasks 1.0.0

### DIFF
--- a/foreman_scc_manager.gemspec
+++ b/foreman_scc_manager.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   # Testing
   s.add_development_dependency 'webmock'
 
-  s.add_dependency 'foreman-tasks', '~> 0.10'
+  s.add_dependency 'foreman-tasks', '>= 0.10'
   s.add_dependency 'rails', '~> 5.1'
 end


### PR DESCRIPTION
foreman-tasks 1.0.0 is not any revolution and only updated vendor to v3, meaning it requires Foreman 1.25, that's the reason for major bump. We may see that more often, so I suggest we drop the major version up limitation.