### PR TITLE
Fix http proxy scenario

### DIFF
--- a/app/lib/actions/scc_manager/sync_products.rb
+++ b/app/lib/actions/scc_manager/sync_products.rb
@@ -20,7 +20,9 @@ module Actions
                                                input.fetch(:login),
                                                decrypt_field(input.fetch(:password)))
           output[:data] = ::SccManager.sanitize_products(products).values
-        rescue StandardError
+        rescue StandardError => e
+          ::Foreman::Logging.logger('foreman_scc_manager').error "Error while syncronizing SCC-Products: #{e}"
+          output[:error] = e.to_s
           output[:status] = 'FAILURE'
         end
       end

--- a/app/lib/actions/scc_manager/sync_repositories.rb
+++ b/app/lib/actions/scc_manager/sync_repositories.rb
@@ -19,7 +19,9 @@ module Actions
                                                     input[:login],
                                                     decrypt_field(input[:password]))
           output[:status] = 'SUCCESS'
-        rescue StandardError
+        rescue StandardError => e
+          ::Foreman::Logging.logger('foreman_scc_manager').error "Error while syncronizing SCC-Repositories: #{e}"
+          output[:error] = e.to_s
           output[:status] = 'FAILURE'
         end
       end

--- a/app/lib/scc_manager.rb
+++ b/app/lib/scc_manager.rb
@@ -8,8 +8,8 @@ module SccManager
       uri.scheme = URI.parse(proxy_config[:host]).scheme
       uri.host = URI.parse(proxy_config[:host]).host
       uri.port = proxy_config[:port].try(:to_s)
-      uri.user = proxy_config[:user].try(:to_s)
-      uri.password = proxy_config[:password].try(:to_s)
+      uri.user = proxy_config[:user]
+      uri.password = proxy_config[:password] if uri.user.present?
 
       RestClient.proxy = uri.to_s
     end

--- a/app/models/scc_account.rb
+++ b/app/models/scc_account.rb
@@ -166,7 +166,8 @@ class SccAccount < ApplicationRecord
   def test_connection
     get_scc_data('/connect/organizations/subscriptions')
     true
-  rescue StandardError
+  rescue StandardError => e
+    logger.warn "Error occurred while testing SCC-Connection to Account #{self}: #{e}"
     false
   end
 

--- a/app/models/scc_account.rb
+++ b/app/models/scc_account.rb
@@ -167,7 +167,7 @@ class SccAccount < ApplicationRecord
     get_scc_data('/connect/organizations/subscriptions')
     true
   rescue StandardError => e
-    logger.warn "Error occurred while testing SCC-Connection to Account #{self}: #{e}"
+    ::Foreman::Logging.logger('foreman_scc_manager').warn "Error occurred while testing SCC-Connection to Account #{self}: #{e}"
     false
   end
 
@@ -186,10 +186,10 @@ class SccAccount < ApplicationRecord
       cached_repository.save!
       upstream_repo_ids << ur['id']
     end
-    logger.debug "Found #{upstream_repo_ids.length} repositories"
+    ::Foreman::Logging.logger('foreman_scc_manager').debug "Found #{upstream_repo_ids.length} repositories"
     # delete repositories beeing removed upstream
     to_delete = scc_repositories.where.not(scc_id: upstream_repo_ids)
-    logger.debug "Deleting #{to_delete.count} old repositories"
+    ::Foreman::Logging.logger('foreman_scc_manager').debug "Deleting #{to_delete.count} old repositories"
     to_delete.destroy_all
   end
 
@@ -209,10 +209,10 @@ class SccAccount < ApplicationRecord
       cached_product.save!
       upstream_product_ids << up['id']
     end
-    logger.debug "Found #{upstream_product_ids.length} products"
+    ::Foreman::Logging.logger('foreman_scc_manager').debug "Found #{upstream_product_ids.length} products"
     # delete products beeing removed upstream
     to_delete = scc_products.where.not(scc_id: upstream_product_ids)
-    logger.debug "Deleting #{to_delete.count} old products"
+    ::Foreman::Logging.logger('foreman_scc_manager').debug "Deleting #{to_delete.count} old products"
     to_delete.destroy_all
     # rewire product to product relationships
     upstream_products.each do |up|
@@ -220,7 +220,7 @@ class SccAccount < ApplicationRecord
       begin
         scc_products.find_by!(scc_id: up['id']).update!(scc_extensions: extensions)
       rescue ActiveRecord::RecordNotFound
-        logger.info "Failed to find parent scc_product '#{up['name']}'."
+        ::Foreman::Logging.logger('foreman_scc_manager').info "Failed to find parent scc_product '#{up['name']}'."
       end
     end
   end


### PR DESCRIPTION
1. fixed error when using an HTTP-Proxy without credentials

1. use correct instance of foreman-logger

1. Add logging of test-connection-errors (currently logging to `warn`, but `info` might also be valid)