### PR TITLE
Fix structure in product selection

### DIFF
--- a/app/views/scc_accounts/show.html.erb
+++ b/app/views/scc_accounts/show.html.erb
@@ -11,7 +11,7 @@
       </span>
       <%= scc_product.friendly_name %>
       <% if scc_product.scc_extensions.any? %>
-        <ul>
+        <ul style='padding-left: 20px;'>
           <% scc_product.scc_extensions.order(:friendly_name).each do |scc_extension| %>
             <% render_list_node(f, scc_extension, parent_id + "_" + scc_product.id.to_s) %>
           <% end %>


### PR DESCRIPTION
In foreman >= 2 the default CSS for the `<ul>`-tag changed `padding-left` to 0. The normal value was `40px`, but I changed it now to `20px` so the layout looks nicer:
![image](https://user-images.githubusercontent.com/1557314/91960441-34d43600-ed0a-11ea-83c5-891115bac52d.png)
