### PR TITLE
Beautifying names of SCC products, repos and descriptions

### DIFF
--- a/app/lib/actions/scc_manager/subscribe_product.rb
+++ b/app/lib/actions/scc_manager/subscribe_product.rb
@@ -8,15 +8,15 @@ module Actions
                           .info("Initiating subscription for SccProduct '#{scc_product.friendly_name}'.")
         sequence do
           product_create_action = plan_action(CreateProduct,
-                                              product_name: scc_product.uniq_name,
-                                              product_description: scc_product.description,
-                                              organization_id: scc_product.organization.id)
+                                              :product_name => scc_product.pretty_name,
+                                              :product_description => scc_product.pretty_description,
+                                              :organization_id => scc_product.organization.id)
           scc_product.scc_repositories.each do |repo|
-            uniq_name = scc_product.uniq_name + ' ' + repo.description
             arch = scc_product.arch || 'noarch'
             plan_action(CreateRepository,
                         :product_id => product_create_action.output[:product_id],
-                        :uniq_name => uniq_name,
+                        :uniq_name => repo.uniq_name(scc_product),
+                        :pretty_repo_name => repo.pretty_name,
                         :url => repo.full_url,
                         :arch => arch)
           end
@@ -58,12 +58,11 @@ module Actions
 
       def create_sub_plans
         product = ::Katello::Product.find(input[:product_id])
-        uniq_name = input[:uniq_name]
-        label = ::Katello::Util::Model.labelize(uniq_name)
+        label = ::Katello::Util::Model.labelize(input[:uniq_name])
         unprotected = true
         gpg_key = product.gpg_key
         repo_param = { :label => label,
-                       :name => uniq_name,
+                       :name => input[:pretty_repo_name],
                        :url => input[:url],
                        :content_type => 'yum',
                        :unprotected => unprotected,

--- a/app/models/scc_repository.rb
+++ b/app/models/scc_repository.rb
@@ -15,6 +15,10 @@ class SccRepository < ApplicationRecord
     scc_product.uniq_name + ' ' + description
   end
 
+  def pretty_name
+    description
+  end
+
   def token_changed_callback
     User.current ||= User.anonymous_admin
     scc_products.where.not(product: nil).find_each do |sp|

--- a/test/fixtures/models/scc_products.yml
+++ b/test/fixtures/models/scc_products.yml
@@ -7,7 +7,7 @@ one:
   version: 1
   arch: x86_128
   friendly_name: number one
-  description: lorem ipsum dolor sit amet
+  description: "<p> lorem ipsum dolor sit amet </p>"
   product_type: base
 
 two:
@@ -17,7 +17,7 @@ two:
   version: 2
   arch: x86_128
   friendly_name: number two
-  description: lorem ipsum dolor sit amet
+  description: "<p> lorem ipsum dolor sit amet </p><p> lorem lorem lorem </p>"
   product_type: extras
 
 three:

--- a/test/fixtures/models/scc_repositories.yml
+++ b/test/fixtures/models/scc_repositories.yml
@@ -13,3 +13,17 @@ repo_<%= i %>:
   installer_updates: false
 <% end %>
 
+repo_9:
+  id: 9
+  scc_account_id: 1
+  scc_id: 63
+  name: SLE10-Debuginfo-Updates_9
+  distro_target: sles_9
+  description: SLE10-Debuginfo-Updates for sles-10-ppc_9
+  url: https://updates.suse.com/repo/example_9
+  token: token_9
+  autorefresh: true
+  installer_updates: false
+
+
+

--- a/test/models/scc_account_test.rb
+++ b/test/models/scc_account_test.rb
@@ -71,4 +71,68 @@ class SccAccountSearchTest < ActiveSupport::TestCase
   end
 end
 
+class SccAccountUpdateProductsTest < ActiveSupport::TestCase
+  def setup
+    @account = scc_accounts(:one)
+    one = scc_products(:one)
+    @account.scc_products = SccProduct.where(name: 'one')
+    # generate test data, beware that hash names are not equal to SccProduct instance names
+    @product_data = { 'name' => one.name,
+                      'id' => one.scc_id,
+                      'version' => one.version,
+                      'arch' => one.arch,
+                      'repositories' => one.scc_repositories,
+                      'extensions' => one.scc_extensions,
+                      'product_type' => one.product_type,
+                      'description' => '<p> new unpretty description </p>',
+                      'friendly_name' => 'updated name' }
+    @product_array = []
+    @product_array.push @product_data
+
+    @test_product = SccProduct.new
+    @test_product.scc_id = @product_data['id']
+    @test_product.friendly_name = @product_data['friendly_name']
+    @test_product.description = @product_data['description']
+  end
+
+  test 'update scc product' do
+    @account.update_scc_products(@product_array)
+    @updated_product = @account.scc_products.where(friendly_name: 'updated name').first
+    assert_equal @test_product.pretty_name, @updated_product.name
+    assert_equal @test_product.pretty_name, @updated_product.pretty_name
+    assert_equal @test_product.pretty_description, @updated_product.description
+    assert_equal @test_product.pretty_description, @updated_product.pretty_description
+  end
+end
+
+class SccAccountUpdateReposTest < ActiveSupport::TestCase
+  def setup
+    @account = scc_accounts(:one)
+    test_repo = scc_repositories(:repo_9)
+    @account.scc_repositories = SccProduct.where(name: 'repo_9')
+    # generate test data
+    @repo_data = { 'name' => test_repo.name,
+                   'id' => test_repo.scc_id,
+                   'distro_target' => test_repo.distro_target,
+                   'url' => test_repo.url,
+                   'enabled' => test_repo.enabled,
+                   'autorefresh' => test_repo.autorefresh,
+                   'installer_updates' => test_repo.installer_updates,
+                   'description' => '<p> new unpretty repo description </p>' }
+    @repo_array = []
+    @repo_array.push @repo_data
+
+    @test_repo = SccRepository.new
+    @test_repo.description = @repo_data['description']
+    @test_repo.name = @repo_data['name']
+  end
+
+  test 'update scc repository' do
+    @account.update_scc_repositories(@repo_array)
+    @updated_repo = @account.scc_repositories.where(name: @test_repo.pretty_name).first
+    assert_equal @test_repo.pretty_name, @updated_repo.name
+    assert_equal @test_repo.pretty_name, @updated_repo.pretty_name
+  end
+end
+
 # FIXME: test cascaded delete

--- a/test/models/scc_product_test.rb
+++ b/test/models/scc_product_test.rb
@@ -3,6 +3,8 @@ require 'test_plugin_helper'
 class SccProductCreateTest < ActiveSupport::TestCase
   def setup
     @product = scc_products(:one)
+    @product_with_ugly_description = scc_products(:two)
+    @product_with_normal_description = scc_products(:three)
   end
 
   test 'create' do
@@ -12,6 +14,17 @@ class SccProductCreateTest < ActiveSupport::TestCase
 
   test 'uniq_name' do
     assert_equal @product.uniq_name, '111 number one'
+  end
+
+  test 'pretty_name' do
+    assert_equal @product.pretty_name, 'number one (id: 111)'
+  end
+
+  test 'pretty_description' do
+    assert_equal @product_with_normal_description.description,
+                 @product_with_normal_description.pretty_description
+    assert_equal @product.pretty_description, 'lorem ipsum dolor sit amet'
+    assert_equal @product_with_ugly_description.pretty_description, 'lorem ipsum dolor sit amet'
   end
 end
 


### PR DESCRIPTION
Add pretty names for products, descriptions and repos. 

ToDo: Not sure how to test the update_products and update_repository functions in the scc_account model. 