### PR TITLE
Choose SUSE GPG Key for subscriptions from SCC Manager

### DIFF
--- a/app/controllers/api/v2/scc_accounts_controller.rb
+++ b/app/controllers/api/v2/scc_accounts_controller.rb
@@ -18,7 +18,7 @@ module Api
       def index
         scope = resource_scope
         scope = scope.where(:organization => params[:organization_id]) if params[:organization_id].present?
-        @scc_accounts = scope.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])
+        @scc_accounts = scope.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page], :per_page => params[:per_page])
       end
 
       api :GET, '/scc_accounts/:id/', N_('Show scc_account')
@@ -35,6 +35,7 @@ module Api
           param :base_url, String, :required => false, :desc => N_('URL of SUSE for scc_account')
           param :interval, ['never', 'daily', 'weekly', 'monthy'], :desc => N_('Interval for syncing scc_account')
           param :sync_date, String, :desc => N_('Last Sync time of scc_account')
+          param :katello_gpg_key_id, :identifier, :required => false, :desc => N_('Associated gpg key of scc_account')
         end
       end
 
@@ -132,7 +133,8 @@ module Api
           :base_url,
           :interval,
           :sync_date,
-          :organization_id
+          :organization_id,
+          :katello_gpg_key_id
         )
       end
 

--- a/app/controllers/scc_accounts_controller.rb
+++ b/app/controllers/scc_accounts_controller.rb
@@ -19,6 +19,7 @@ class SccAccountsController < ApplicationController
   def new
     @scc_account = SccAccount.new
     @scc_account.organization = @organization
+    find_available_gpg_keys
   end
 
   # POST /scc_accounts
@@ -31,7 +32,9 @@ class SccAccountsController < ApplicationController
   end
 
   # GET /scc_accounts/1/edit
-  def edit; end
+  def edit
+    find_available_gpg_keys
+  end
 
   # POST /scc_accounts/test_connection
   def test_connection
@@ -98,6 +101,10 @@ class SccAccountsController < ApplicationController
 
   private
 
+  def find_available_gpg_keys
+    @selectable_gpg_keys = ::Katello::GpgKey.where(organization: @scc_account.organization).collect { |p| [p.name, p.id] }.unshift ['None', nil]
+  end
+
   def find_organization
     @organization = Organization.current
     redirect_to '/select_organization?toState=' + request.path unless @organization
@@ -114,7 +121,8 @@ class SccAccountsController < ApplicationController
       :base_url,
       :interval,
       :sync_date,
-      :organization_id
+      :organization_id,
+      :katello_gpg_key_id
     )
   end
 

--- a/app/lib/actions/scc_manager/subscribe_product.rb
+++ b/app/lib/actions/scc_manager/subscribe_product.rb
@@ -10,7 +10,8 @@ module Actions
           product_create_action = plan_action(CreateProduct,
                                               :product_name => scc_product.pretty_name,
                                               :product_description => scc_product.pretty_description,
-                                              :organization_id => scc_product.organization.id)
+                                              :organization_id => scc_product.organization.id,
+                                              :gpg_key => scc_product.scc_account.katello_gpg_key_id)
           scc_product.scc_repositories.each do |repo|
             arch = scc_product.arch || 'noarch'
             plan_action(CreateRepository,
@@ -43,6 +44,7 @@ module Actions
       def create_sub_plans
         product = ::Katello::Product.new
         product.name = input[:product_name]
+        product.gpg_key = ::Katello::GpgKey.find_by(id: input[:gpg_key], organization: input[:organization_id])
         product.description = input[:product_description]
         trigger(::Actions::Katello::Product::Create,
                 product,

--- a/app/views/scc_accounts/_form.html.erb
+++ b/app/views/scc_accounts/_form.html.erb
@@ -1,3 +1,4 @@
+<!-- see foreman/app/helper/form_helper.rb -->
 <% javascript 'foreman_scc_manager/scc_accounts'  %>
 
 <%= form_for(@scc_account) do |f| %>
@@ -18,6 +19,11 @@
         <%= field f, :sync_date, label: _('Sync Date') do
           f.datetime_field :sync_date, placeholder: Time.now
         end %>
+       <%= selectable_f f, :katello_gpg_key_id, @selectable_gpg_keys, {}, 
+                        { :include_blank => _("None"), 
+                          :label => _('Use GPG key for SUSE products'), 
+                          :selected => @scc_account.katello_gpg_key_id, 
+                          :help_block => _("Use this setting if you want to automatically add a GPG key to your SUSE products upon subscription. You can change this setting in the 'Content' > 'Products' menu, later.") } %>
         <div class='clearfix'>
           <div class='form-group'>
             <div class='col-md-2'></div>

--- a/db/migrate/20201119084201_add_gpg_key_to_scc_account.rb
+++ b/db/migrate/20201119084201_add_gpg_key_to_scc_account.rb
@@ -1,0 +1,6 @@
+class AddGpgKeyToSccAccount < ActiveRecord::Migration[5.2]
+  def change
+    add_column :scc_accounts, :katello_gpg_key_id, :integer,  null: true
+    add_foreign_key :scc_accounts, :katello_gpg_keys, column: :katello_gpg_key_id, on_delete: :nullify
+  end
+end

--- a/locale/foreman_scc_manager.pot
+++ b/locale/foreman_scc_manager.pot
@@ -192,6 +192,14 @@ msgid ""
 " of any imported products."
 msgstr ""
 
+#: ../app/views/scc_accounts/_form.html.erb:22
+msgid "Use GPG key for SUSE products"
+msgstr ""
+
+#: ../app/views/scc_accounts/_form.html.erb:22
+msgid "Use this setting if you want to automatically add a GPG key to your SUSE products upon subscription. You can change this setting in the 'Content' > 'Products' menu, later."
+msgstr ""
+
 #: ../app/views/scc_accounts/_form.html.erb:18
 msgid "Sync Date"
 msgstr ""

--- a/test/controllers/scc_accounts_controller_test.rb
+++ b/test/controllers/scc_accounts_controller_test.rb
@@ -1,0 +1,146 @@
+require 'test_plugin_helper'
+
+class SccAccountsControllerTest < ActionController::TestCase
+  def setup
+    @scc_account = scc_accounts(:one)
+  end
+
+  def stub_custom_request(url, host = 'scc.example.com', auth = 'Basic b25ldXNlcjpvbmVwYXNz')
+    stub_request(:get, url)
+      .with(
+        headers: {
+          'Accept' => 'application/vnd.scc.suse.com.v4+json',
+          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Authorization' => auth,
+          'Host' => host,
+          'User-Agent' => "rest-client/2.1.0 (linux-gnu x86_64) ruby/#{RUBY_VERSION}p#{RUBY_PATCHLEVEL}"
+        }
+      )
+      .to_return(status: 200, body: '', headers: {})
+  end
+
+  test 'should get new' do
+    get :new, session: set_session_user
+    assert_response :success
+    assert_select 'title', 'Add SUSE Customer Center Account'
+  end
+
+  test 'should get edit' do
+    get :edit, params: { :id => @scc_account.id }, session: set_session_user
+    assert_response :success
+    assert_select 'title', "Edit #{@scc_account.name}"
+  end
+
+  test 'should get index' do
+    get :index, session: set_session_user
+    assert_response :success
+    assert_not_nil assigns(:scc_accounts)
+    body = @response.body
+    assert_not_empty body
+    assert_select 'title', 'SUSE subscriptions'
+  end
+
+  test 'should show scc_account' do
+    get :show, params: { :id => @scc_account.id }, session: set_session_user
+
+    assert_not_nil assigns(:scc_account)
+    assert_response :success
+    assert_select 'title', "Product Selection for Account #{@scc_account.name}"
+  end
+
+  test 'should 404 for unknown scc_account' do
+    get :show, params: { :id => 'does-not-exist' }, session: set_session_user
+
+    assert_response :not_found
+  end
+
+  test 'should create scc_account' do
+    account = scc_accounts(:two)
+    organization = get_organization
+    assert organization
+    assert account
+    assert_difference('SccAccount.count') do
+      post :create, params:
+                        { :scc_account => { :name => account.name, :login => account.login, :password => account.password, :organization_id => organization.id } },
+                    session: set_session_user
+    end
+  end
+
+  test 'should update scc_account' do
+    account = scc_accounts(:two)
+    put :update, params: { id: account.id, :scc_account => { :sync_date => Time.now, :interval => 'weekly' } }, session: set_session_user
+
+    assert_equal 'weekly', assigns(:scc_account).interval
+  end
+
+  #  test 'new account SCC server connection-test' do
+  #    stub_custom_request("https://scc.example.com/connect/organizations/subscriptions", "scc.suse.com", 'Basic Og==')
+  #
+  #    account = scc_accounts(:one)
+  #    assert account
+  #    post :test_connection, params: { :scc_account => { :login => account.login, :password => account.password, :base_url => account.base_url } }, session: set_session_user
+  #
+  #    assert_response :ok
+  #  end
+
+  #  test 'new account SCC server fail connection-test' do
+  #    stub_custom_request('https://scc.example.com/connect/organizations/subscriptions', "scc.suse.com", 'Basic Og==')
+  #
+  #    account = scc_accounts(:one)
+  #    assert account
+  #    post :test_connection, params: { :scc_account => { :login => account.login, :password => account.password, :base_url => account.base_url } }, session: set_session_user
+  #
+  #    assert_response :not_found
+  #    assert_match response.body, '"Failed"'
+  #  end
+  #
+  #  test 'existing account SCC server connection-test' do
+  #    stub_custom_request('https://scc.suse.com/connect/organizations/subscriptions', 'scc.suse.com', 'Basic Og==')
+
+  #    account = scc_accounts(:one)
+  #    assert account
+  #    put :test_connection, params: { :scc_account => {:id => account.id } }, session: set_session_user
+  #
+  #    assert_response :ok
+  #  end
+  # --> fails because of ActionController::UnknownFormat error
+
+  #  test 'existing account SCC server fail connection-test' do
+  #    stub_custom_request('https://scc.example.com/connect/organizations/subscriptions', "scc.suse.com", 'Basic Og==')
+  #    account = scc_accounts(:one)
+  #    assert account
+  #    post :test_connection, params: { :id => account.id }, session: set_session_user
+  #
+  #    assert_response :not_found
+  #    assert_match response.body, '"Failed"'
+  #  end
+  #
+  test 'SCC server sync products' do
+    stub_custom_request('https://scc.example.com/connect/organizations/products')
+    stub_custom_request('https://scc.example.com/connect/organizations/repositories')
+
+    account = scc_accounts(:one)
+    assert account
+    put :sync, params: { :id => account.id }, session: set_session_user
+    assert_redirected_to '/scc_accounts'
+  end
+
+  test 'SCC server bulk subscribe products' do
+    stub_custom_request('https://scc.example.com/connect/organizations/repositories')
+
+    account = scc_accounts(:one)
+    product1 = scc_products(:one)
+    product2 = scc_products(:two)
+    account.scc_products = [product1, product2]
+    put :bulk_subscribe, params: { :id => account.id, :scc_account => { :scc_subscribe_product_ids => [product1.id, product2.id] } }, session: set_session_user
+
+    assert_redirected_to '/scc_accounts'
+  end
+
+  test 'should delete scc_account' do
+    account = scc_accounts(:two)
+    assert_difference 'SccAccount.count', -1 do
+      delete :destroy, params: { :id => account.id }, session: set_session_user
+    end
+  end
+end

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -22,6 +22,7 @@ module FixtureTestCase
     Dir.mkdir(self.fixture_path)
     FileUtils.cp(Dir.glob("#{ForemanSccManager::Engine.root}/test/fixtures/models/*"), self.fixture_path)
     FileUtils.cp(Dir.glob("#{ForemanSccManager::Engine.root}/test/fixtures/files/*"), self.fixture_path)
+    FileUtils.cp(Dir.glob("#{ForemanSccManager::Engine.root}/test/fixtures/controllers/*"), self.fixture_path)
     FileUtils.cp(Dir.glob("#{Rails.root}/test/fixtures/*"), self.fixture_path)
     fixtures(:all)
     FIXTURES = load_fixtures(ActiveRecord::Base)
@@ -54,5 +55,13 @@ class ActiveSupport::TestCase
     organization.save!
     User.current = saved_user
     organization
+  end
+end
+
+class ActionController::TestCase
+  def set_session_user(user = :admin, org = :empty_organization)
+    user = user.is_a?(User) ? user : users(user)
+    org = org.is_a?(Organization) ? org : taxonomies(org)
+    { :user => user.id, :expires_at => 5.minutes.from_now, :organization_id => org.id }
   end
 end


### PR DESCRIPTION
* Add database field for the usage of gpg keys (use_gpg_key) --> Now ID of gpg key

* Add check box to Scc Account options to enable GPG keys --> Now a selection field

* Add gpg key functionality in the suscribe_product action

New:
![image](https://user-images.githubusercontent.com/71487468/99778565-22e97e80-2b14-11eb-91e5-81ab8e1f1b7f.png)
![image](https://user-images.githubusercontent.com/71487468/99778648-3dbbf300-2b14-11eb-863c-b5854a539594.png)



Old:
![image](https://user-images.githubusercontent.com/71487468/99525331-f3af0200-2999-11eb-8df9-7d7510d33815.png)