### PR TITLE
Add product id to product selection list

### DIFF
--- a/app/views/scc_accounts/show.html.erb
+++ b/app/views/scc_accounts/show.html.erb
@@ -11,7 +11,7 @@
           <%= check_box_tag("scc_account[scc_subscribe_product_ids][]", scc_product.id, false) %>
         <% end %>
       </span>
-      <%= scc_product.friendly_name %>
+      <%= scc_product.pretty_name %>
       <% if scc_product.scc_extensions.any? %>
         <ul style='padding-left: 20px;'>
           <% scc_filtered_products(scc_product.scc_extensions, 'extension').each do |scc_extension| %>


### PR DESCRIPTION
Product names in Scc Manager selection should be the same as Katello products.
New: Scc Manager product list with ids
![image](https://user-images.githubusercontent.com/71487468/100088718-da51fe00-2e50-11eb-9d88-e4a048956c67.png)

Katello Products:
![image](https://user-images.githubusercontent.com/71487468/100088823-07061580-2e51-11eb-8e33-93cc3f7eea08.png)

