### PR TITLE
Drop mirror on sync for SLES reposistories

### DIFF
--- a/app/lib/actions/scc_manager/subscribe_product.rb
+++ b/app/lib/actions/scc_manager/subscribe_product.rb
@@ -121,11 +121,8 @@ module Actions
                        :arch => input[:arch],
                        :download_policy => Setting[:default_download_policy] }
         repository = product.add_repo(repo_param)
-        if repository.has_attribute?('mirror_on_sync')
-          repository.mirror_on_sync = true
-        else
-          repository.mirroring_policy = ::Katello::RootRepository::MIRRORING_POLICY_CONTENT
-        end
+        repository.mirroring_policy = ::Katello::RootRepository::MIRRORING_POLICY_CONTENT
+
         if repository.has_attribute?('upstream_authentication_token')
           repository.url = input[:url]
           repository.upstream_authentication_token = input[:token]

--- a/app/models/scc_product.rb
+++ b/app/models/scc_product.rb
@@ -58,11 +58,8 @@ class SccProduct < ApplicationRecord
       gpg_key = new_product.gpg_key
       new_repo = new_product.add_repo(label, uniq_repo_name, repo.url, 'yum', unprotected, gpg_key)
       new_repo.arch = arch || 'noarch'
-      if new_repo.has_attribute?('mirror_on_sync')
-        new_repo.mirror_on_sync = true
-      else
-        new_repo.mirroring_policy = ::Katello::RootRepository::MIRRORING_POLICY_CONTENT
-      end
+      new_repo.mirroring_policy = ::Katello::RootRepository::MIRRORING_POLICY_CONTENT
+
       if new_repo.has_attribute?('upstream_authentication_token')
         new_repo.upstream_authentication_token = repo.token
         new_repo.url = repo.url


### PR DESCRIPTION
mirror on sync may not work for pulp3 repositories because pulp3 don't
support drpm. Therefore it is necessary to always use content-only mode.