### PR TITLE
Fix Add Products button not being active

### DIFF
--- a/webpack/components/SCCProductPage/components/SCCProductPicker/components/SCCTreePicker/index.js
+++ b/webpack/components/SCCProductPage/components/SCCProductPicker/components/SCCTreePicker/index.js
@@ -158,11 +158,13 @@ const SCCTreePicker = ({
       selectedRepos[productId].repoIds = repoIds;
       selectedRepos[productId].productName = productName;
       selectedRepos[productId].repoNames = repoNames;
+      const newSelectedRepos = clone(selectedRepos);
+      setSelectedRepos(newSelectedRepos);
     } else if (selectedRepos !== {} && productId in selectedRepos) {
       delete selectedRepos[productId];
+      const newSelectedRepos = clone(selectedRepos);
+      setSelectedRepos(newSelectedRepos);
     }
-    const newSelectedRepos = clone(selectedRepos);
-    setSelectedRepos(newSelectedRepos);
   };
 
   const [sccProductTree, setSccProductTree] = useState(


### PR DESCRIPTION
The button would only be active based if the last TreeViewListItem that is visible on the page is checked. It would disregard all other checkboxes as the state of the would be recalculated and emptied for every Item. To prevent that it now only changes the state if the user clicks a checkbox empty or not.