### PR TITLE
Fix rubocop test broken by psych 5 libyaml availability

### DIFF
--- a/.github/workflows/rubocop.yaml
+++ b/.github/workflows/rubocop.yaml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: sudo apt-get update
+      - run: sudo apt-get install libyaml-dev
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Fixing rubocop tests based on @ekohl 's hint https://github.com/ATIX-AG/foreman_scc_manager/pull/115#issuecomment-1354761075