### PR TITLE
Fix reading of test fixtures

### DIFF
--- a/test/controllers/api/v2/scc_accounts_test.rb
+++ b/test/controllers/api/v2/scc_accounts_test.rb
@@ -17,7 +17,7 @@ class Api::V2::SccAccountsControllerTest < ActionController::TestCase
         }
       ).to_return(
         status: 200,
-        body: fixture_file_upload('data_subscriptions.json').read,
+        body: scc_fixture_file('data_subscriptions.json'),
         headers: {
           server: 'nginx',
           date: 'Tue, 05 Mar 2019 15:07:38 GMT',
@@ -56,7 +56,7 @@ class Api::V2::SccAccountsControllerTest < ActionController::TestCase
         }
       ).to_return(
         status: 200,
-        body: fixture_file_upload('data_repositories.json').read,
+        body: scc_fixture_file('data_repositories.json'),
         headers: {
           server: 'nginx',
           date: 'Mon, 07 Oct 2019 13:14:31 GMT',
@@ -95,7 +95,7 @@ class Api::V2::SccAccountsControllerTest < ActionController::TestCase
         }
       ).to_return(
         status: 200,
-        body: fixture_file_upload('data_products_page1.json').read,
+        body: scc_fixture_file('data_products_page1.json'),
         headers: {
           server: 'nginx',
           date: 'Mon, 11 Mar 2019 15:37:00 GMT',
@@ -132,7 +132,7 @@ class Api::V2::SccAccountsControllerTest < ActionController::TestCase
         }
       ).to_return(
         status: 200,
-        body: fixture_file_upload('data_products_page2.json').read,
+        body: scc_fixture_file('data_products_page2.json'),
         headers: {
           server: 'nginx',
           date: 'Mon, 11 Mar 2019 15:37:19 GMT',

--- a/test/features/sync_test.rb
+++ b/test/features/sync_test.rb
@@ -13,7 +13,7 @@ class SccAccountSyncTest < ActiveSupport::TestCase
         }
       ).to_return(
         status: 200,
-        body: fixture_file_upload('data_subscriptions.json').read,
+        body: scc_fixture_file('data_subscriptions.json'),
         headers: {
           server: 'nginx',
           date: 'Tue, 05 Mar 2019 15:07:38 GMT',
@@ -52,7 +52,7 @@ class SccAccountSyncTest < ActiveSupport::TestCase
         }
       ).to_return(
         status: 200,
-        body: fixture_file_upload('data_products_page1.json').read,
+        body: scc_fixture_file('data_products_page1.json'),
         headers: {
           server: 'nginx',
           date: 'Mon, 11 Mar 2019 15:37:00 GMT',
@@ -89,7 +89,7 @@ class SccAccountSyncTest < ActiveSupport::TestCase
         }
       ).to_return(
         status: 200,
-        body: fixture_file_upload('data_products_page1.json').read,
+        body: scc_fixture_file('data_products_page1.json'),
         headers: {
           server: 'nginx',
           date: 'Mon, 11 Mar 2019 15:37:19 GMT',

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -23,7 +23,6 @@ module FixtureTestCase
     FileUtils.rm_rf(self.fixture_path) if File.directory?(self.fixture_path)
     Dir.mkdir(self.fixture_path)
     FileUtils.cp(Dir.glob("#{ForemanSccManager::Engine.root}/test/fixtures/models/*"), self.fixture_path)
-    FileUtils.cp(Dir.glob("#{ForemanSccManager::Engine.root}/test/fixtures/files/*"), self.fixture_path)
     FileUtils.cp(Dir.glob("#{ForemanSccManager::Engine.root}/test/fixtures/controllers/*"), self.fixture_path)
     FileUtils.cp(Dir.glob(Rails.root.join('test/fixtures/*')), self.fixture_path)
     fixtures(:all)
@@ -51,6 +50,10 @@ class ActiveSupport::TestCase
     organization.save!
     User.current = saved_user
     organization
+  end
+
+  def scc_fixture_file(filename)
+    File.read(File.join(ForemanSccManager::Engine.root, 'test', 'fixtures', 'files', filename))
   end
 end
 


### PR DESCRIPTION
Test fixtures could not be read. Switching to an explicit reading of the fixture files similar to Foreman Ansible:

https://github.com/theforeman/foreman_ansible/blob/8b03e3d26bdbbf4462ad34f8cfd91a20a78aedf4/test/test_plugin_helper.rb#L5