### PR TITLE
Don't use evr-enabled PostgreSQL container in tests

### DIFF
--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -23,5 +23,4 @@ jobs:
     with:
       plugin: foreman_scc_manager
       matrix_exclude: '[{"ruby": "3.0", "node": "14"}]'
-      postgresql_container: ghcr.io/theforeman/postgresql-evr
       test_existing_database: false


### PR DESCRIPTION
The postgresql-evr extension no longer required starting Foreman 3.14/Katello 4.16