### PR TITLE
Hide loc/org params from api

### DIFF
--- a/app/controllers/api/v2/scc_accounts_controller.rb
+++ b/app/controllers/api/v2/scc_accounts_controller.rb
@@ -8,6 +8,8 @@ module Api
         resource_id 'scc_accounts'
         api_version 'v2'
         api_base_url '/api/v2'
+        param :location_id, Integer, :show => false
+        param :organization_id, Integer, :show => false
       end
 
       before_action :find_resource, :only => [:show, :update, :destroy, :sync, :bulk_subscribe, :bulk_subscribe_with_repos]

--- a/app/controllers/api/v2/scc_products_controller.rb
+++ b/app/controllers/api/v2/scc_products_controller.rb
@@ -8,6 +8,8 @@ module Api
         resource_id 'scc_products'
         api_version 'v2'
         api_base_url '/api/v2'
+        param :location_id, Integer, :show => false
+        param :organization_id, Integer, :show => false
       end
 
       before_action :find_resource, :only => [:show, :subscribe]


### PR DESCRIPTION
We don't need those parameters because only the scc account is bound to an organization which is passed in the scc account specific parameter set.

Careful: This only **hides** the parameters from api! They are still available and can be passed to the application.