### PR TITLE
add dependabot config for Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
I copied this over from here: https://github.com/markt-de/foreman_ovirt/pull/16 

I think it is a good idea to be up-to-date with the test environment. 