### PR TITLE
Correct branch name in rubocop workflow to master

### DIFF
--- a/.github/workflows/js_tests.yml
+++ b/.github/workflows/js_tests.yml
@@ -2,6 +2,7 @@ name: JavaScript Testing
 on:
   push:
     branches:
+      - main
       - master
   pull_request:
     paths:

--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -4,6 +4,7 @@ name: Ruby Tests
   push:
     branches:
       - main
+      - master
   pull_request:
 
 concurrency:


### PR DESCRIPTION
OR: We rename the master branch to 'main' ;) 