### PR TITLE
Fix HttpProxy password is not decrypted before usage

### DIFF
--- a/app/lib/scc_manager.rb
+++ b/app/lib/scc_manager.rb
@@ -1,13 +1,7 @@
 module SccManager
   # adapted from https://github.com/SUSE/connect
   def self.get_scc_data(base_url, rest_url, login, password)
-    if (proxy_config = ::HttpProxy.default_global_content_proxy)
-      uri = URI(proxy_config[:url])
-      uri.user = proxy_config[:username]
-      uri.password = proxy_config[:password] if uri.user.present?
-
-      RestClient.proxy = uri.to_s
-    end
+    RestClient.proxy = ::HttpProxy.default_global_content_proxy.full_url if ::HttpProxy.default_global_content_proxy
 
     url = base_url + rest_url
     credentials = Base64.encode64("#{login}:#{password}").chomp

--- a/test/lib/scc_manager_test.rb
+++ b/test/lib/scc_manager_test.rb
@@ -60,5 +60,34 @@ class SccManagerTest < ActiveSupport::TestCase
           @dummy_password)
       end
     end
+
+    test 'uses HTTP-Proxy' do
+      ::HttpProxy.any_instance.stubs(:encryption_key).returns('25d224dd383e92a7e0c82b8bf7c985e8')
+      proxy = FactoryBot.build(:http_proxy)
+      proxy.username = 'dummy'
+      proxy.password = 'secret'
+      proxy.save!
+      default_global_proxy_backup = Setting[:content_default_http_proxy]
+      Setting[:content_default_http_proxy] = proxy.name
+
+      # ensure password is saved encrypted and decrypted before use
+      assert_not_equal 'secret', proxy[:password]
+      assert_include proxy.full_url, 'secret'
+      RestClient.expects(:proxy=).with(proxy.full_url)
+      RestClient.expects(:proxy=).with('')
+      stub_request(:get, "#{@dummy_base_url}#{@dummy_path}")
+        .with(@default_headers)
+        .to_return(status: 200,
+          body: '[{ "foo": "bar" }]',
+          headers: {})
+
+      results = ::SccManager.get_scc_data(@dummy_base_url,
+        @dummy_path,
+        @dummy_login,
+        @dummy_password)
+      assert_equal results[0]['foo'], 'bar'
+
+      Setting[:content_default_http_proxy] = default_global_proxy_backup
+    end
   end
 end


### PR DESCRIPTION
Fixes #182

When using transparently encrypted attributes we have to make sure to use the Getter-method and not read the attribute using the `[]`-operator.

~~ToDo:~~ Tests :sweat_smile: :heavy_check_mark: 