### PR TITLE
chore(lint): fix new eslint findings

### DIFF
--- a/webpack/components/SCCAccountForm/components/DateTimeField.js
+++ b/webpack/components/SCCAccountForm/components/DateTimeField.js
@@ -8,6 +8,8 @@ import {
 } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 
+const HOURS_DAY_MAX = 12;
+
 export const formatDateTime = (dateStr, timeStr) => {
   if (!dateStr || !timeStr) return undefined;
 
@@ -16,7 +18,8 @@ export const formatDateTime = (dateStr, timeStr) => {
 
   const [, hourStr, minuteStr, ampm] = match;
   const hour24 =
-    (parseInt(hourStr, 10) % 12) + (ampm.toUpperCase() === 'PM' ? 12 : 0);
+    (parseInt(hourStr, 10) % HOURS_DAY_MAX) +
+    (ampm.toUpperCase() === 'PM' ? HOURS_DAY_MAX : 0);
 
   const [year, month, day] = dateStr.split('-').map(Number);
   if (!year || !month || !day) return undefined;

--- a/webpack/components/SCCAccountIndex/SCCAccountIndexActions.js
+++ b/webpack/components/SCCAccountIndex/SCCAccountIndexActions.js
@@ -3,6 +3,8 @@ import { translate as __ } from 'foremanReact/common/I18n';
 
 import { INITIAL_DELAY, MAX_DELAY, BACKOFF } from './SCCAccountIndexConstants';
 
+const TIMEOUT_API_MSEC = 15000;
+
 const isDone = (state, result) =>
   state === 'stopped' || result === 'success' || result === 'error';
 
@@ -157,7 +159,7 @@ export const syncSccAccountAction = (
             taskTimeoutRef,
             lastStateRef
           );
-        }, 15000);
+        }, TIMEOUT_API_MSEC);
       },
       handleError: () => {
         setAccounts((prev) =>

--- a/webpack/components/SCCProductPage/components/SCCProductPicker/components/SCCGenericPicker/index.js
+++ b/webpack/components/SCCProductPage/components/SCCProductPicker/components/SCCGenericPicker/index.js
@@ -16,6 +16,8 @@ import { TimesIcon } from '@patternfly/react-icons';
 import { translate as __ } from 'foremanReact/common/I18n';
 import '../../../SCCProductPicker/styles.scss';
 
+const NO_RESULTS = __('no results');
+
 const GenericSelector = ({
   initialSelectOptions,
   setSelected,
@@ -34,7 +36,6 @@ const GenericSelector = ({
   );
   const [focusedItemIndex, setFocusedItemIndex] = useState(null);
   const [activeItemId, setActiveItemId] = useState(null);
-  const NO_RESULTS = __('no results');
 
   useEffect(() => {
     let newSelectOptions = initialSelectOptions.map((option) => ({
@@ -61,7 +62,7 @@ const GenericSelector = ({
       }
     }
     setSelectOptions(newSelectOptions);
-  }, [filterValue, initialSelectOptions]);
+  }, [filterValue, initialSelectOptions, isOpen]);
   const createItemId = (value) =>
     `select-typeahead-${value?.replace(' ', '-')}`;
   const setActiveAndFocusedItem = (itemIndex) => {

--- a/webpack/components/SCCProductPage/components/SCCProductPicker/components/SCCTreePicker/components/SCCRepoPicker/index.js
+++ b/webpack/components/SCCProductPage/components/SCCProductPicker/components/SCCTreePicker/components/SCCRepoPicker/index.js
@@ -111,6 +111,7 @@ const SCCRepoPicker = ({
     activateDebugFilter,
     productAlreadySynced,
     sccProductId,
+    sccProductName,
     setSelectedReposFromChild,
   ]);
 


### PR DESCRIPTION
`no-magic-numbers`: plain integer values should not be used within code, but defined as a constant with a descriptive name
`react-hooks/exhaustive-deps`: make sure useEffect-hooks get the correct list of variables whose change should trigger a re-run.

## ToDo:

Fix remaining Linter warnings of type `react-hooks/exhaustive-deps`:
```
/home/runner/work/foreman_scc_manager/foreman_scc_manager/foreman_scc_manager/webpack/components/SCCProductPage/components/SCCProductPicker/components/SCCTreePicker/index.js
Warning:   186:6  warning  React Hook useEffect has missing dependencies: 'activateDebugFilter', 'selectedRepos', and 'setSelectedReposFromChild'. Either include them or remove the dependency array. You can also replace multiple useState variables with useReducer if 'setSccProductTree' needs the current value of 'activateDebugFilter'  react-hooks/exhaustive-deps